### PR TITLE
do not stringify nil env vars

### DIFF
--- a/lib/cellect/server/adapters/panoptes.rb
+++ b/lib/cellect/server/adapters/panoptes.rb
@@ -13,7 +13,7 @@ module Cellect
 
         def workflow_list(*names)
           with_pg do |pg|
-            statement = 'SELECT * FROM workflows'
+            statement = 'SELECT * FROM workflows '
             statement += case names.length
                          when 0
                            ""

--- a/start
+++ b/start
@@ -35,6 +35,9 @@ rescue Errno::ENOENT
   ZK_URL = "#{ENV["ZK_PORT_2181_TCP_ADDR"]}:#{ENV["ZK_PORT_2181_TCP_PORT"]}"
 end
 
-puma_cmd = "puma -b tcp://0.0.0.0:80 -t 8:64"
+puma_cmd = "puma -b tcp://0.0.0.0:80 -t 8:16"
 
-exit system("ZK_URL=#{ZK_URL} PG_POOL_SIZE=#{PG_POOL_SIZE} PG_HOST=#{PG_HOST} PG_PORT=#{PG_PORT} PG_DB=#{PG_DB} PG_USER=#{PG_USER} PG_PASS=#{PG_PASS} #{puma_cmd}")
+env_vars = { "ZK_URL" => ZK_URL, "PG_POOL_SIZE" => PG_POOL_SIZE,
+             "PG_HOST" => PG_HOST, "PG_PORT" => PG_PORT, "PG_DB" => PG_DB,
+             "PG_USER" => PG_USER, "PG_PASS" =>PG_PASS }
+exit system(env_vars, puma_cmd)


### PR DESCRIPTION
a blank string env var passed to connection pool causes a blocking timeout as there are 0 connections to use since ENV.fetch returns a blank string instead of nil.

Also cellect runs on MRI ruby so adding 64 max threads seems like overkill, although cellect will do a bit of blocking HTTP work.