### PR TITLE
Add support for newrelic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .ruby-*
 tmp/*
+log/
+newrelic.yml

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "activerecord"
 gem "connection_pool"
 gem "oj"
 gem "cellect-server"
+gem 'newrelic_rpm'
 group :development do
   gem "rspec"
   gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
     minitest (5.5.1)
     multi_json (1.10.1)
     multi_xml (0.5.5)
+    newrelic_rpm (3.10.0.279)
     nio4r (1.1.0)
     oj (2.11.4)
     pg (0.18.1)
@@ -126,6 +127,7 @@ DEPENDENCIES
   activerecord
   cellect-server
   connection_pool
+  newrelic_rpm
   oj
   pg
   postgres_ext

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,4 @@
+require 'newrelic_rpm'
 require 'cellect/server'
 require_relative 'lib/cellect/server/adapters/panoptes'
 

--- a/fig.yml
+++ b/fig.yml
@@ -21,6 +21,7 @@ cellect:
   ports:
     - "4000:80"
   environment:
+    - "ENVIRONMENT=development"
     - "DEBUG_CELLECT_START=true"
     - "PUMA_MAX_THREADS=64"
   links:


### PR DESCRIPTION
Sorry this took me a little longer to get around to today.

It will automatically instrument the Grape Routes and the ActiveRecord queries. We just need to drop the newrelic configuration in the application in the deployed verison. 