### PR TITLE
pass RACK_ENV in to load the correct env for db and puma

### DIFF
--- a/cellect_env.rb
+++ b/cellect_env.rb
@@ -14,13 +14,14 @@ module CellectEnv
     load_zk_yaml
     @env_vars = { "ZK_URL" => @zk_url, "PG_POOL" => stringify_value(@pg_pool),
                   "PG_HOST" => @pg_host, "PG_PORT" => stringify_value(@pg_port),
-                  "PG_DB" => @pg_db, "PG_USER" => @pg_user, "PG_PASS" => @pg_pass }
+                  "PG_DB" => @pg_db, "PG_USER" => @pg_user, "PG_PASS" => @pg_pass,
+                  "RACK_ENV" => @environment }
   end
 
   private
 
   def setup_environment
-    @environment = ENV['ENVIRONMENT']
+    @environment = ENV['RACK_ENV']
     if @environment == nil
       @environment = 'production'
     end

--- a/fig.yml
+++ b/fig.yml
@@ -21,7 +21,7 @@ cellect:
   ports:
     - "4000:80"
   environment:
-    - "ENVIRONMENT=development"
+    - "RACK_ENV=development"
     - "DEBUG_CELLECT_START=true"
     - "PUMA_MAX_THREADS=64"
   links:


### PR DESCRIPTION
allow puma to report it's env correctly (development by default) and to load the correct DB 

depends on https://github.com/zooniverse/infrastructure/pull/13