### PR TITLE
use a connection string for zk urls

### DIFF
--- a/cellect_env.rb
+++ b/cellect_env.rb
@@ -51,7 +51,7 @@ module CellectEnv
     begin
       zookeepers = YAML.load(File.read("/production_config/zookeeper.yml"))
       zk = zookeepers[@environment]
-      @zk_url = "#{zk['host']}:#{zk['port']}"
+      @zk_url = zk['url']
     rescue Errno::ENOENT
       @zk_url = "#{ENV["ZK_PORT_2181_TCP_ADDR"]}:#{ENV["ZK_PORT_2181_TCP_PORT"]}"
     end


### PR DESCRIPTION
allow cluster ip:port strings to be combined into one URL. Production config files have been updated already.