### PR TITLE
use mri 2.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zooniverse/ruby:2.2.0
+FROM zooniverse/ruby:2.2.1
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
2.2.1 fixes a memory leak, see the changelog https://www.ruby-lang.org/en/news/2015/03/03/ruby-2-2-1-released