### PR TITLE
preload workflow data and logging

### DIFF
--- a/cellect_env.rb
+++ b/cellect_env.rb
@@ -10,12 +10,13 @@ module CellectEnv
 
   def setup_env_vars
     setup_environment
+    preload_workflows
     load_db_yaml
     load_zk_yaml
     @env_vars = { "ZK_URL" => @zk_url, "PG_POOL" => stringify_value(@pg_pool),
                   "PG_HOST" => @pg_host, "PG_PORT" => stringify_value(@pg_port),
                   "PG_DB" => @pg_db, "PG_USER" => @pg_user, "PG_PASS" => @pg_pass,
-                  "RACK_ENV" => @environment }
+                  "RACK_ENV" => @environment, "PRELOAD_WORKFLOWS" => @preload_workflows }
   end
 
   private
@@ -25,6 +26,11 @@ module CellectEnv
     if @environment == nil
       @environment = 'production'
     end
+  end
+
+  def preload_workflows
+    ids = (ENV['PRELOAD_WORKFLOWS'] || "").split(",")
+    @preload_workflows = ids.map(&:to_i).select { |int| int != 0 }.join(",")
   end
 
   def load_db_yaml

--- a/config.ru
+++ b/config.ru
@@ -4,4 +4,11 @@ require_relative 'lib/cellect/server/adapters/panoptes'
 
 Cellect::Server.adapter = Cellect::Server::Adapters::Panoptes.new
 
+# provide the ability to preload workflow data sets on boot
+workflows_to_load_on_boot = ENV['PRELOAD_WORKFLOWS']
+workflows_to_load_on_boot.split(",").each do |workflow_id|
+  puts "Preloading workflow: #{workflow_id}"
+  Cellect::Server.adapter.load_workflows(workflow_id)
+end
+
 run Cellect::Server::API

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,1 @@
 #!/usr/bin/env puma
-
-stdout_redirect '/cellect_panoptes/log/puma_stdout.log', '/cellect_panoptes/log/puma_stderr.log'

--- a/fig.yml
+++ b/fig.yml
@@ -24,6 +24,7 @@ cellect:
     - "RACK_ENV=development"
     - "DEBUG_CELLECT_START=true"
     - "PUMA_MAX_THREADS=64"
+    - "PRELOAD_WORKFLOWS=1"
   links:
     - postgres:pg
     - zookeeper:zk

--- a/start
+++ b/start
@@ -22,7 +22,7 @@ class CellectStart
   private
 
   def setup_puma_cmd
-    @puma_cmd = "puma -b tcp://0.0.0.0:80 -t 0:#{puma_max_threads} -C config/puma.rb"
+    @puma_cmd = "puma -b tcp://0.0.0.0:80 -t 0:#{puma_max_threads}"
   end
 
   def puma_max_threads

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -6,3 +6,7 @@ user=root
 command=/cellect_panoptes/start
 directory=/cellect_panoptes
 autorestart=true
+stdout_logfile=/cellect_panoptes/log/puma_stdout.log
+stdout_logfile_maxbytes=0
+stderr_logfile=/cellect_panoptes/log/puma_stderr.log
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
allow env vars to setup workflow ids that will get their data loaded on boot. Pay this cost before coming online. Also a fix for logging in here.