### PR TITLE
Allow specifying puma port in env

### DIFF
--- a/cellect_start
+++ b/cellect_start
@@ -27,7 +27,7 @@ class CellectStart
   end
 
   def puma_port
-    ENV['RACK_ENV'] == "production" ? 80 : 4000
+    ENV['PUMA_PORT'] || 4000
   end
 
   def puma_max_threads


### PR DESCRIPTION
We don't want it to run on port 80 in production (but we might in the future), so we may as well make this more easily configurable.