### PR TITLE
distinct subjects

### DIFF
--- a/lib/cellect/server/adapters/panoptes.rb
+++ b/lib/cellect/server/adapters/panoptes.rb
@@ -60,6 +60,7 @@ module Cellect
               .joins("LEFT OUTER JOIN subject_workflow_counts ON subject_workflow_counts.subject_id = set_member_subjects.subject_id")
               .where('subject_workflow_counts.retired_at IS NULL')
               .select(:subject_id, :priority, :subject_set_id)
+              .distinct
           end
 
           subject_data.map do |row|

--- a/lib/cellect/server/adapters/panoptes.rb
+++ b/lib/cellect/server/adapters/panoptes.rb
@@ -58,7 +58,7 @@ module Cellect
               .joins(:workflows)
               .where(workflows: {id: workflow_id})
               .joins("LEFT OUTER JOIN subject_workflow_counts ON subject_workflow_counts.subject_id = set_member_subjects.subject_id")
-              .where('subject_workflow_counts.id IS NULL OR subject_workflow_counts.retired_at IS NULL')
+              .where('subject_workflow_counts.retired_at IS NULL')
               .select(:subject_id, :priority, :subject_set_id)
           end
 


### PR DESCRIPTION
this will create a unique list of subject_id, priority, group based on the sms data. Not sure if cellect will take it into account when loading for non-grouped workflows though.