### PR TITLE
Bump cellect

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "postgres_ext", '~> 2.4.1'
 gem "activerecord", '~> 4.2.5'
 gem "connection_pool", '~> 2.2.0'
 gem "oj", '~> 2.13.1'
-gem "cellect-server", '~> 2.0.0.beta4'
+gem "cellect-server", '~> 2.1.0'
 gem 'newrelic_rpm', '~> 3.14'
 gem 'grape-activerecord', '~> 1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.4.0)
     arel (6.0.3)
-    attention (0.0.4)
+    attention (0.0.5)
       connection_pool (~> 2)
       redis (~> 3)
       redis-namespace (~> 1.5)
@@ -25,10 +25,10 @@ GEM
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
     builder (3.2.2)
-    cellect-server (2.0.0.beta4)
+    cellect-server (2.1.0)
       attention (~> 0.0.4)
       celluloid (= 0.16.0)
-      diff_set (~> 0.0.3)
+      diff_set (~> 0.0.4)
       grape (~> 0.7)
       http (~> 0.6)
     celluloid (0.16.0)
@@ -40,9 +40,9 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
-    diff_set (0.0.3)
-      rice (~> 1.7)
-    domain_name (0.5.25)
+    diff_set (0.0.4)
+      rice (~> 2.1.0)
+    domain_name (0.5.20160615)
       unf (>= 0.0.5, < 1.0.0)
     equalizer (0.0.11)
     grape (0.13.0)
@@ -62,8 +62,8 @@ GEM
     hashie (3.4.3)
     hashie-forbidden_attributes (0.1.1)
       hashie (>= 3.0)
-    hitimes (1.2.3)
-    http (0.9.8)
+    hitimes (1.2.4)
+    http (0.9.9)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
       http-form_data (~> 1.0.1)
@@ -97,10 +97,10 @@ GEM
       rack (>= 0.4)
     rack-mount (0.8.3)
       rack (>= 1.0.0)
-    redis (3.2.2)
+    redis (3.3.0)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
-    rice (1.7.0)
+    rice (2.1.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -122,7 +122,7 @@ GEM
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.2)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -134,7 +134,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 4.2.5)
-  cellect-server (~> 2.0.0.beta4)
+  cellect-server (~> 2.1.0)
   connection_pool (~> 2.2.0)
   grape-activerecord (~> 1.0)
   newrelic_rpm (~> 3.14)
@@ -146,4 +146,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.11.2
+   1.12.4


### PR DESCRIPTION
This updates both cellect and diff_set to be fully compatible with Ruby 2.3.

This may also solve some of the memory consumption issues we had been looking into.