### PR TITLE
ensure retired subjects are not loaded for a specific workflow

### DIFF
--- a/lib/cellect/server/adapters/panoptes.rb
+++ b/lib/cellect/server/adapters/panoptes.rb
@@ -27,6 +27,11 @@ module Cellect
 
         class UserSeenSubject < ActiveRecord::Base
         end
+
+        class SubjectWorkflowCount < ActiveRecord::Base
+          belongs_to :subject
+          belongs_to :workflow
+        end
       end
 
       class Panoptes < Default

--- a/lib/cellect/server/adapters/panoptes.rb
+++ b/lib/cellect/server/adapters/panoptes.rb
@@ -64,7 +64,11 @@ module Cellect
             subject_data_scope = PanoptesAssociation::SetMemberSubject
               .joins(:workflows)
               .where(workflows: {id: workflow_id})
-              .joins("LEFT OUTER JOIN subject_workflow_counts ON subject_workflow_counts.subject_id = set_member_subjects.subject_id")
+              .joins(
+                "LEFT OUTER JOIN subject_workflow_counts " \
+                "ON subject_workflow_counts.subject_id = set_member_subjects.subject_id"
+              )
+              .where('subject_workflow_counts.workflow_id': workflow_id)
               .where('subject_workflow_counts.retired_at IS NULL')
               .select(:id, :subject_id, :priority, :subject_set_id)
 

--- a/lib/cellect/server/adapters/panoptes.rb
+++ b/lib/cellect/server/adapters/panoptes.rb
@@ -31,6 +31,12 @@ module Cellect
         class SubjectWorkflowCount < ActiveRecord::Base
           belongs_to :subject
           belongs_to :workflow
+
+          def self.sanitized_workflow_join(workflow_id)
+            sanitize_sql_for_conditions(
+              ['subject_workflow_counts.workflow_id = ?', workflow_id]
+            )
+          end
         end
       end
 
@@ -66,9 +72,9 @@ module Cellect
               .where(workflows: {id: workflow_id})
               .joins(
                 "LEFT OUTER JOIN subject_workflow_counts " \
-                "ON subject_workflow_counts.subject_id = set_member_subjects.subject_id"
+                "ON subject_workflow_counts.subject_id = set_member_subjects.subject_id " \
+                "AND #{PanoptesAssociation::SubjectWorkflowCount.sanitized_workflow_join(workflow_id)}"
               )
-              .where('subject_workflow_counts.workflow_id': workflow_id)
               .where('subject_workflow_counts.retired_at IS NULL')
               .select(:id, :subject_id, :priority, :subject_set_id)
 

--- a/spec/panoptes_adapter_spec.rb
+++ b/spec/panoptes_adapter_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe Cellect::Server::Adapters::Panoptes do
     set_class.destroy_all
     subject_class.destroy_all
     workflow_class.destroy_all
+    swc_class.destroy_all
   end
 
   describe "ActiveRecord connection" do

--- a/spec/panoptes_adapter_spec.rb
+++ b/spec/panoptes_adapter_spec.rb
@@ -165,10 +165,10 @@ RSpec.describe Cellect::Server::Adapters::Panoptes do
         )
       end
 
-      it "should not load the subject", :focus do
+      it "should not load the subject" do
         retired_loaded_workflow_swc
         retired_non_loaded_workflow_swc
-        binding.pry
+        expect(loaded_data).not_to be_empty
         expect(loaded_data[retired_subject_id]).to be_nil
       end
     end

--- a/spec/panoptes_adapter_spec.rb
+++ b/spec/panoptes_adapter_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Cellect::Server::Adapters::Panoptes do
   let(:set_workflow_join_class) { Cellect::Server::Adapters::PanoptesAssociation::SubjectSetsWorkflow}
   let(:subject_class) { Cellect::Server::Adapters::PanoptesAssociation::SetMemberSubject }
   let(:uss_class) { Cellect::Server::Adapters::PanoptesAssociation::UserSeenSubject }
+  let(:swc_class) { Cellect::Server::Adapters::PanoptesAssociation::SubjectWorkflowCount }
 
   let(:workflows) do
     w1 = workflow_class.create! do |w|
@@ -128,8 +129,12 @@ RSpec.describe Cellect::Server::Adapters::Panoptes do
   end
 
   describe '#load_data_for' do
-    it 'should load data for the given workflow' do
-      subjects # not created yet
+    it 'should load data for the given workflow', :focus do
+      # retire 1 subject for the non-loaded workflows
+      non_loaded_workflow = (worklfows - [loaded_workflow]).first
+      retired_in_other_workflow_subject = subjects.sample
+      swc_class.create!(workflow: non_loaded_workflow, subject: retired_in_other_workflow_subject, retired_at: Time.now)
+
       db_data = []
       subject.load_data_for(loaded_workflow.id) do |hash|
         db_data << hash

--- a/spec/panoptes_adapter_spec.rb
+++ b/spec/panoptes_adapter_spec.rb
@@ -130,23 +130,46 @@ RSpec.describe Cellect::Server::Adapters::Panoptes do
   end
 
   describe '#load_data_for' do
-    it 'should load data for the given workflow', :focus do
-      # retire 1 subject for the non-loaded workflows
-      non_loaded_workflow = (worklfows - [loaded_workflow]).first
-      retired_in_other_workflow_subject = subjects.sample
-      swc_class.create!(workflow: non_loaded_workflow, subject: retired_in_other_workflow_subject, retired_at: Time.now)
-
+    let(:loaded_data) do
       db_data = []
       subject.load_data_for(loaded_workflow.id) do |hash|
         db_data << hash
       end
-      data = db_data.group_by{ |h| h['id'] }
+      db_data.group_by{ |h| h['id'] }
+    end
+
+    it 'should load data for the given workflow' do
       subjects.each do |panoptes_subject|
-        cellect_subject = data[panoptes_subject.subject_id].first
+        cellect_subject = loaded_data[panoptes_subject.subject_id].first
         expect(cellect_subject).to be_present
         expect(cellect_subject['id']).to eql panoptes_subject.subject_id
         expect(cellect_subject['group_id']).to eql panoptes_subject.subject_set_id
         expect(cellect_subject['priority']).to be_within(0.1).of 1 / panoptes_subject.priority.to_f
+      end
+    end
+
+    context "when a subject is retired for the loaded workflow but not another" do
+      let(:non_loaded_workflow) { (workflows - [loaded_workflow]).first }
+      let(:retired_subject_id) { subjects.sample.subject_id }
+      let(:retired_loaded_workflow_swc) do
+        swc_class.create(
+          workflow_id: loaded_workflow.id,
+          subject_id: retired_subject_id,
+          retired_at: Time.now
+        )
+      end
+      let(:retired_non_loaded_workflow_swc) do
+        swc_class.create!(
+          workflow_id: non_loaded_workflow.id,
+          subject_id: retired_subject_id
+        )
+      end
+
+      it "should not load the subject", :focus do
+        retired_loaded_workflow_swc
+        retired_non_loaded_workflow_swc
+        binding.pry
+        expect(loaded_data[retired_subject_id]).to be_nil
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,4 +8,5 @@ ActiveRecord::Base.logger.level = 1
 
 RSpec.configure do |config|
   config.disable_monkey_patching!
+  config.filter_run focus: true
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,4 +9,5 @@ ActiveRecord::Base.logger.level = 1
 RSpec.configure do |config|
   config.disable_monkey_patching!
   config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
Only take into account the subject workflow counts for the workflow in question, ignore any other workflows that a subject may be linked to. 

This fixes a bug noticed in wildcam gorongosa where retired subjects were being loaded for the specified workflow even though they were retired for that workflow. This was due to the `left outer join` taking any matching `subject_id` irrespective of the workflow id on the `subject_workflow_count` model. 