### PR TITLE
Remove debug cellect env var

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -20,8 +20,6 @@ spec:
           env:
             - name: RACK_ENV
               value: "production"
-            - name: DEBUG_CELLECT_START
-              value: "false"
             - name: PUMA_PORT
               value: "80"
           ports:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -20,8 +20,6 @@ spec:
           env:
             - name: RACK_ENV
               value: "staging"
-            - name: DEBUG_CELLECT_START
-              value: "false"
             - name: PUMA_PORT
               value: "80"
           ports:


### PR DESCRIPTION
closes #98 

presence of the DEBUG_CELLECT_START env var will print these values on app boot, https://github.com/zooniverse/cellect_panoptes/blob/c27e85469813cc330a2fabcc7a7111f4a3aad3f3/cellect_start#L16