### PR TITLE
Fix broken grape rack gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "oj", '~> 2.13.1'
 gem "cellect-server", '~> 3.0.1'
 gem 'newrelic_rpm', '~> 5.2'
 gem "otr-activerecord" ,'~> 1.2'
+gem 'rack', '~> 2.0.9'
 
 group :development, :test do
   gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
       method_source (~> 0.9.0)
     public_suffix (3.0.1)
     puma (3.12.4)
-    rack (2.2.2)
+    rack (2.0.9)
     rack-accept (0.4.5)
       rack (>= 0.4)
     redis (3.3.5)
@@ -149,7 +149,8 @@ DEPENDENCIES
   postgres_ext (~> 2.4.1)
   pry
   puma (~> 3.11)
+  rack (~> 2.0.9)
   rspec
 
 BUNDLED WITH
-   1.16.0
+   1.16.6

--- a/README.md
+++ b/README.md
@@ -19,4 +19,9 @@ Use the docker-compose tool to get started.
 4. Once all that is done you can run the specs via
   + `RACK_ENV=test DATABASE_URL=postgresql://panoptes:panoptes@localhost:6000/cellect_panoptes_test rspec`
 
+Or use docker-compose to get a bash session in the container
+1. `docker-compose run --rm --entrypoint="bash" cellect`
+0. `RACK_ENV=test rake db:setup`
+0. `RACK_ENV=test rspec`
+
 Don't forget to tear down the daemonized postgres container when your done.


### PR DESCRIPTION
downgrade rack to 2.0.9 - however this leaves us vulnerable to CVE-2020-8161

I manually checked the installed gems for the 'Rack::Directory' use and did not find any. Assuming we're ok for this one based on advisory in https://github.com/rubysec/ruby-advisory-db/blob/master/gems/rack/CVE-2020-8161.yml

root@42d9f60300fa:/usr/local/lib/ruby/gems/2.3.0/gems# grep -iRl "Rack::Directory" ./
./rack-2.0.9/test/spec_directory.rb
./rack-2.0.9/lib/rack/directory.rb
./rack-2.0.9/HISTORY.md
./rack-2.2.2/CHANGELOG.md
./rack-2.2.2/lib/rack/directory.rb
./rack-2.2.2/README.rdoc