### PR TITLE
Increase k8s ram

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -19,10 +19,10 @@ spec:
           image: zooniverse/cellect-panoptes:__IMAGE_TAG__
           resources:
              requests:
-               memory: "150Mi"
+               memory: "250Mi"
                cpu: "10m"
              limits:
-               memory: "250Mi"
+               memory: "500Mi"
                cpu: "500m"
           env:
             - name: RACK_ENV

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -22,7 +22,7 @@ spec:
                memory: "150Mi"
                cpu: "10m"
              limits:
-               memory: "150Mi"
+               memory: "250Mi"
                cpu: "500m"
           env:
             - name: RACK_ENV

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -22,7 +22,7 @@ spec:
                memory: "100Mi"
                cpu: "10m"
              limits:
-               memory: "100Mi"
+               memory: "200Mi"
                cpu: "500m"
           env:
             - name: RACK_ENV


### PR DESCRIPTION
cellect is still actively used for for some projects and is being used for Engaging Crowds FEM subject selection so will see more traffic on live projects. Accordingly give this prod app more RAM to run and avoid OOM killer app restarts which harm service behaviours

